### PR TITLE
Fix: some checks as RUNTEQ correct answer example

### DIFF
--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -3,18 +3,20 @@ require 'rails_helper'
 RSpec.describe Task, type: :model do
   describe 'validation' do
     it 'is valid with all attributes' do 
-      expect(build(:task)).to be_valid
+      task = build(:task)
+      expect(task).to be_valid
+      expect(task.errors).to be_empty
     end
   
     it 'is invalid without a title' do 
       task = build(:task, title: nil)
-      task.valid?
+      expect(task).to be_invalid
       expect(task.errors[:title]).to include("can't be blank")
     end
   
     it 'is invalid without a status' do
       task = build(:task, status: nil)
-      task.valid?
+      expect(task).to be_invalid
       expect(task.errors[:status]).to include("can't be blank")    
     end
   
@@ -25,7 +27,7 @@ RSpec.describe Task, type: :model do
     it 'is invalid with a duplicated title' do
       original = create(:task)
       task = build(:task, title: original.title)
-      task.valid?
+      expect(task).to be_invalid
       expect(task.errors[:title]).to include("has already been taken")    
     end
 
@@ -33,6 +35,7 @@ RSpec.describe Task, type: :model do
       create(:task)
       task = build(:task)
       expect(task).to be_valid
+      expect(task.errors).to be_empty
     end
   end
 end


### PR DESCRIPTION
不正チェックの修正

```diff
- task.valid?
+ expect(task).to be_invalid
```

正常系のエラーがないチェックの追加
```diff
 expect(task.errors).to be_empty
```
